### PR TITLE
hiding copper because copper isnt required

### DIFF
--- a/content/planets/redono.hjson
+++ b/content/planets/redono.hjson
@@ -56,6 +56,7 @@ landCloudColor: ff4f4f
 parent: serpulo
 alwaysUnlocked: true
 hiddenItems: [
+        "copper",
         "lead",
         "scrap",
         "graphite",


### PR DESCRIPTION
we can hide copper because players can use redum-shards instead