### PR TITLE
Suggestions

### DIFF
--- a/content/blocks/redono/drills/redum-drill.hjson
+++ b/content/blocks/redono/drills/redum-drill.hjson
@@ -22,5 +22,5 @@ consumes: {
   }
 }
 tier:2
-drillTime:550
+drillTime:500
 size:2

--- a/content/blocks/redono/turrets/lust.hjson
+++ b/content/blocks/redono/turrets/lust.hjson
@@ -41,7 +41,7 @@ progress: warmup
 }
 
 requirements: [
-redum-shards/10
+redum-shards/16
 ]
 
 ammoTypes: {
@@ -87,11 +87,12 @@ speed: 12
 lifetime: 10
 damage: 20
 splashDamage: 24
-splashDamageRadius: 12
+splashDamageRadius: 24
 width: 6
 height: 8
 collidesGround: true
 collidesAir: true
+ammoMultiplier: 8
 hitEffect: flakExplosionBig
 pierce: true
 pierceCap: 4

--- a/content/blocks/redono/walls/redum-wall-large.hjson
+++ b/content/blocks/redono/walls/redum-wall-large.hjson
@@ -1,6 +1,6 @@
 type:Wall
 requirements:[
-redum-shards/80]
+redum-shards/60]
 name:"Large redium wall"
 size:2
 category:defense

--- a/content/blocks/redono/walls/redum-wall.hjson
+++ b/content/blocks/redono/walls/redum-wall.hjson
@@ -1,6 +1,6 @@
 type:Wall
 requirements:[
-redum-shards/20
+redum-shards/14
 ]
 name:"Redium wall"
 category:defense

--- a/content/units/redono/guard.hjson
+++ b/content/units/redono/guard.hjson
@@ -1,6 +1,6 @@
 
 type: mech
-speed: 0.7
+speed: 1.4
 buildSpeed: 2.5
 buildRange: 320
 mineSpeed: 8
@@ -9,7 +9,7 @@ mineTier: 1
 riseSpeed: 0.12
 canBoost: true
 engineOffset: 6
-engineSize: 2
+engineSize: 2.5
 lowAltitude: true
 hitSize: 10
 armor: 2
@@ -41,12 +41,12 @@ x: 0
 y: 0
 shootY: 1.5
 shootSound: sap
-reload: 24
+reload: 22
 recoil: 0
 bullet: {
 type: SapBulletType
 speed: 0
-damage: 12
+damage: 18
 sapStrength: 0.6
 length: 120
 collidesGround: true
@@ -73,11 +73,11 @@ x: 7.75
 y: 0
 shootY: 6.5
 shootSound: laser
-reload: 9
+reload: 36
 recoil: 1.75
 bullet: {
 type: LaserBulletType
-damage: 30
+damage: 50
 length: 120
 width: 6
 hitSize: 4

--- a/content/units/redono/internal/tesla-block-unit.hjson
+++ b/content/units/redono/internal/tesla-block-unit.hjson
@@ -1,11 +1,14 @@
 type:tether
 flying:true
+hittable: false
+playerControllable: false
 health: 200
 speed: 0
-drag: 0
+drag: 1
 name:"Active tesla"
 outlineColor: 262626
 outlineRadius: 0
+engineSize: 0
 abilities : [{
         
         hitBuildings : true

--- a/content/units/redono/red-fly1.hjson
+++ b/content/units/redono/red-fly1.hjson
@@ -1,6 +1,6 @@
 type:flying
 flying:true
-health: 98
+health: 230
 speed:2.8
 drag: 0.04
 name:"Call"
@@ -8,7 +8,7 @@ outlineColor: 262626
 weapons:[
 {
 mirror : true
-        reload : 12
+        reload : 20
         name : redumlare-gun
         top: false
         x : 3

--- a/content/units/redono/red-ground1.hjson
+++ b/content/units/redono/red-ground1.hjson
@@ -4,7 +4,7 @@
     lightRadius : 30
     lightColor : ff4f4f
     flying : false
-    health : 230
+    health : 460
     speed : 1.22
     range : 115
     name : Redox
@@ -36,20 +36,20 @@
             lifetime : 20
             hitColor : ff4f4f
             shrinkY : 0
-            damage : 10
+            damage : 12
             sprite : circle-bullet
             recoil : 1
             speed : 5
             height : 9
             width : 7
             type : BasicBulletType
-            fragBullets: 4
+            fragBullets: 3
             fragBullet: {
                 type: BasicBulletType
                 height: 6
                 width: 4
                 speed: 3
-                damage: 4
+                damage: 5
                 lifetime: 5
             }
             

--- a/content/units/redono/red-ground2.hjson
+++ b/content/units/redono/red-ground2.hjson
@@ -4,7 +4,7 @@
     lightColor : ff4f4f
     flying : false
     hitSize: 14
-    health : 670
+    health : 850
     speed : 0.8
     range : 180
     name : Ronix
@@ -20,7 +20,7 @@
         
         shootSound : none
         mirror : true
-        reload : 90
+        reload : 95
         name : ronix-weapon
         top: false
         x : 5.75
@@ -32,7 +32,7 @@
             lightColor : ff4f4f
             despawnHit : true
             backColor : ff4f4f
-            lifetime : 30
+            lifetime : 38
             hitColor : ff4f4f
             shrinkY : 0
             damage : 20
@@ -40,7 +40,7 @@
             recoil : 1
             speed : 5
             height : 10
-            width : 8
+            width : 6
             type : BasicBulletType
             fragBullets: 5
             fragBullet: {
@@ -50,7 +50,7 @@
                 speed: 3
                 drag: 0.1
                 damage: 10
-                lifetime: 20
+                lifetime: 30
                 sprite : circle-bullet
                 backColor : ff4f4f
                 frontColor : ffffff
@@ -68,7 +68,7 @@
                     width: 4
                     speed: -5
                     damage: 12
-                    lifetime: 8
+                    lifetime: 16
                     sprite : circle-bullet
                     backColor : ff4f4f
                     frontColor : ffffff


### PR DESCRIPTION
I've played through a mod and wanted to suggest a few edits. You may edit theese if you don't like the values.

-Make the drill slightly faster to reduce the grind

I don't think i need to explain this - in many levels you are barely given any redium ore, and its basically the lifeblood in this mod, so you just sit and wait.

-Buff all units,especially t1, because at the moment they are overpriced

Lust costs 10 shards (16 if you accept the PR), while the t1 mech needs 20 shards and 20 redium. so a total of 100 shards, for something with 230 hp. The t1 flyer has 90 hp and dies practically instantly, have you playtested the last level? 

-Nerf Lust cost and buff its Redium ammo

Lust costs 10 shards like I said, its way too cheap. Sure it has low health but its dps is great for something that costs 10 shards. Also, because redium is 4 times more valuable than shards, the ammo for it should also be 4 times better. 


I also fixed some things like t2's range and tesla's unit.

Also also, you should say somewhere that you should rebind the boost keybind, because atm there is a bug where the unit will boost and will not enter command mode, making you unable to rally your units.